### PR TITLE
Added nvda-mathcat submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -42,3 +42,6 @@
 	path = .vscode
 	url = https://github.com/nvaccess/vscode-nvda.git
 	ignore = dirty
+[submodule "include/nvda-mathcat"]
+	path = include/nvda-mathcat
+	url = https://github.com/nvaccess/nvda-mathcat.git


### PR DESCRIPTION
This PR adds MathCAT assets under include/nvda-mathcat as a submodule. We are opening this as a separate PR to create this submodule before the main PR is merged for the MathCAT integration project so that we will have access to this submodule for testing the GitHub Actions workflow that automatically fetches assets from the latest MathCAT release.